### PR TITLE
tox.ini: Use {posargs} so that test runner arguments can be passed to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py26, py27, pypy, py33
 
 [testenv]
-commands = python run-tests.py
+commands = python run-tests.py {posargs}


### PR DESCRIPTION
E.g.: `tox -e py26 -- -v jinja2.testsuite.core_tags`