### PR TITLE
Duplication of index and search links on main page of documentation.

### DIFF
--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -21,9 +21,3 @@ Additional Information
 
    faq
    changelog
-
-If you can't find the information you're looking for, have a look at the
-index or try to find it using the search function:
-
-* :ref:`genindex`
-* :ref:`search`


### PR DESCRIPTION
![2013-07-16 7 21 43](https://f.cloud.github.com/assets/249795/804030/f3625d8c-ee01-11e2-8596-6ba01bfe4ca9.png)

So I fixed it.