### PR TITLE
Custom Filters example inserts escaped <br>s

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -607,7 +607,7 @@ enabled::
 
     @evalcontextfilter
     def nl2br(eval_ctx, value):
-        result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', '<br>\n')
+        result = u'\n\n'.join(u'<p>%s</p>' % p.replace('\n', Markup('<br>\n'))
                               for p in _paragraph_re.split(escape(value)))
         if eval_ctx.autoescape:
             result = Markup(result)


### PR DESCRIPTION
The example nl2br custom filter inserts escaped `&lt;br&gt;` <br> tags as the `Markup.replace` method seems to pass `str`/`unicode` arguments through `escape`.