### PR TITLE
Dict: Mapping iterable object

### DIFF
--- a/jinja2/defaults.py
+++ b/jinja2/defaults.py
@@ -32,7 +32,7 @@ from jinja2.filters import FILTERS as DEFAULT_FILTERS
 from jinja2.tests import TESTS as DEFAULT_TESTS
 DEFAULT_NAMESPACE = {
     'range':        range_type,
-    'dict':         lambda **kw: kw,
+    'dict':         lambda *a, **kw: kw or dict(a),
     'lipsum':       generate_lorem_ipsum,
     'cycler':       Cycler,
     'joiner':       Joiner


### PR DESCRIPTION
usage example:
{{ dict(("a", 1), ("b", 2)) }} --> {'a': 1, 'b': 2}