### PR TITLE
Updated template documentation examples

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -24,7 +24,7 @@ the template.  The template syntax is heavily inspired by Django and Python.
 Below is a minimal template that illustrates a few basics.  We will cover
 the details later in that document::
 
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+    <!DOCTYPE html>
     <html lang="en">
     <head>
         <title>My Webpage</title>
@@ -322,9 +322,8 @@ This template, which we'll call ``base.html``, defines a simple HTML skeleton
 document that you might use for a simple two-column page. It's the job of
 "child" templates to fill the empty blocks with content::
 
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+    <!DOCTYPE html>
     <html lang="en">
-    <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         {% block head %}
         <link rel="stylesheet" href="style.css" />
@@ -339,6 +338,7 @@ document that you might use for a simple two-column page. It's the job of
             {% endblock %}
         </div>
     </body>
+    </html>
 
 In this example, the ``{% block %}`` tags define four blocks that child templates
 can fill in. All the `block` tag does is to tell the template engine that a


### PR DESCRIPTION
Fixed html tags in base template example. Since I was removing the
xmlns="http://www.w3.org/1999/xhtml" tag, it seemed like a good time to
update the examples to the html5 doctype.

(in response to issue: https://github.com/mitsuhiko/jinja2/issues/394)