### PR TITLE
Replace lambda for 'dict' in with dict itself

### DIFF
--- a/jinja2/defaults.py
+++ b/jinja2/defaults.py
@@ -32,7 +32,7 @@ from jinja2.filters import FILTERS as DEFAULT_FILTERS
 from jinja2.tests import TESTS as DEFAULT_TESTS
 DEFAULT_NAMESPACE = {
     'range':        range_type,
-    'dict':         lambda **kw: kw,
+    'dict':         dict,
     'lipsum':       generate_lorem_ipsum,
     'cycler':       Cycler,
     'joiner':       Joiner


### PR DESCRIPTION
lambda **kw: kw is not equivalent to the dict constructor. It is much less useful.
In particular it doesn't accept a sequence of pairs.
Why not put dict itself into the DEFAULT_NAMESPACE?
Principle of least surprise, etc.