### PR TITLE
Fix `long_integer is number` check in Python 2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Version 2.8
   reloaded now.
 - Implemented a block ``set`` tag.
 - Default cache size was incrased to 400 from a low 50.
+- Fixed ``is number`` test to accept long integers in all Python versions.
 
 Version 2.7.3
 -------------

--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -22,6 +22,7 @@ if not PY2:
     range_type = range
     text_type = str
     string_types = (str,)
+    integer_types = (int,)
 
     iterkeys = lambda d: iter(d.keys())
     itervalues = lambda d: iter(d.values())
@@ -51,6 +52,7 @@ else:
     text_type = unicode
     range_type = xrange
     string_types = (str, unicode)
+    integer_types = (int, long)
 
     iterkeys = lambda d: d.iterkeys()
     itervalues = lambda d: d.itervalues()

--- a/jinja2/tests.py
+++ b/jinja2/tests.py
@@ -11,7 +11,7 @@
 import re
 from collections import Mapping
 from jinja2.runtime import Undefined
-from jinja2._compat import text_type, string_types
+from jinja2._compat import text_type, string_types, integer_types
 
 
 number_re = re.compile(r'^-?\d+(\.\d+)?$')
@@ -88,7 +88,7 @@ def test_mapping(value):
 
 def test_number(value):
     """Return true if the variable is a number."""
-    return isinstance(value, (int, float, complex))
+    return isinstance(value, integer_types + (float, complex))
 
 
 def test_sequence(value):

--- a/jinja2/testsuite/tests.py
+++ b/jinja2/testsuite/tests.py
@@ -51,13 +51,15 @@ class TestsTestCase(JinjaTestCase):
             {{ {} is mapping }}
             {{ mydict is mapping }}
             {{ [] is mapping }}
+            {{ 10 is number }}
+            {{ (10 ** 100) is number }}
         ''')
         class MyDict(dict):
             pass
         assert tmpl.render(mydict=MyDict()).split() == [
             'False', 'True', 'False', 'True', 'True', 'False',
             'True', 'True', 'True', 'True', 'False', 'True',
-            'True', 'True', 'False'
+            'True', 'True', 'False', 'True', 'True'
         ]
 
     def test_sequence(self):

--- a/jinja2/testsuite/tests.py
+++ b/jinja2/testsuite/tests.py
@@ -53,13 +53,15 @@ class TestsTestCase(JinjaTestCase):
             {{ [] is mapping }}
             {{ 10 is number }}
             {{ (10 ** 100) is number }}
+            {{ 3.14159 is number }}
+            {{ complex is number }}
         ''')
         class MyDict(dict):
             pass
-        assert tmpl.render(mydict=MyDict()).split() == [
+        assert tmpl.render(mydict=MyDict(), complex=complex(1, 2)).split() == [
             'False', 'True', 'False', 'True', 'True', 'False',
             'True', 'True', 'True', 'True', 'False', 'True',
-            'True', 'True', 'False', 'True', 'True'
+            'True', 'True', 'False', 'True', 'True', 'True', 'True'
         ]
 
     def test_sequence(self):


### PR DESCRIPTION
While making Jinja Python3-compatible, the check for long was removed instead of being replaced with version-specific `integer_types`.

Also added testcases for `float` and `complex` numbers.