### PR TITLE
Use PEP440-compatible dev version

### DIFF
--- a/jinja2/__init__.py
+++ b/jinja2/__init__.py
@@ -27,7 +27,7 @@
     :license: BSD, see LICENSE for more details.
 """
 __docformat__ = 'restructuredtext en'
-__version__ = '2.8-dev'
+__version__ = '2.8.dev0'
 
 # high level interface
 from jinja2.environment import Environment, Template

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ from setuptools import setup
 
 setup(
     name='Jinja2',
-    version='2.8-dev',
+    version='2.8.dev0',
     url='http://jinja.pocoo.org/',
     license='BSD',
     author='Armin Ronacher',


### PR DESCRIPTION
This fixes the problem of python packaging considering an installed dev version older than 0.0.