### PR TITLE
docs/templates.rst I've adjusted the example so that it will work in python2 and python3.

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -542,7 +542,7 @@ As variables in templates retain their object properties, it is possible to
 iterate over containers like `dict`::
 
     <dl>
-    {% for key, value in my_dict.iteritems() %}
+    {% for key, value in my_dict.items() %}
         <dt>{{ key|e }}</dt>
         <dd>{{ value|e }}</dd>
     {% endfor %}


### PR DESCRIPTION
It is not quite as efficient in python2 as not a generator.  But does work.