### PR TITLE
Fix literal \ characters at the end of a string

### DIFF
--- a/ext/Vim/jinja.vim
+++ b/ext/Vim/jinja.vim
@@ -59,8 +59,8 @@ syn match jinjaFunction contained /[a-zA-Z_][a-zA-Z0-9_]*/
 syn match jinjaBlockName contained /[a-zA-Z_][a-zA-Z0-9_]*/
 
 " Jinja template constants
-syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\\"/ end=/"/
-syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\\'/ end=/'/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\"/ end=/"/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\'/ end=/'/
 syn match jinjaNumber containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[0-9]\+\(\.[0-9]\+\)\?/
 
 " Operators


### PR DESCRIPTION
Given a statement like `{% set sep = '\\' %}`, the syntax highlighter was considering the literal `'\\'` to be a literal quote inside the string by matching `\'` and thus highlighting the rest of the entire document as a string.

This change fixes that issue by adding some regex to ensure that an escaped quote is preceded by an uneven number of slashes (that is, `'\\\\\''` would accept the literal string `\\'` without issues). A`"` quoted string is modified the same way.