### PR TITLE
Change py2 print statements to py3 in example test_ files

### DIFF
--- a/examples/basic/test.py
+++ b/examples/basic/test.py
@@ -24,4 +24,4 @@ env = Environment(loader=DictLoader({
 
 
 tmpl = env.get_template("child.html")
-print tmpl.render()
+print(tmpl.render())

--- a/examples/basic/test_filter_and_linestatements.py
+++ b/examples/basic/test_filter_and_linestatements.py
@@ -22,4 +22,4 @@ tmpl = env.from_string("""\
 % endfilter
 """)
 
-print tmpl.render(seq=range(10))
+print(tmpl.render(seq=range(10)))

--- a/examples/basic/test_loop_filter.py
+++ b/examples/basic/test_loop_filter.py
@@ -9,4 +9,4 @@ tmpl = Environment().from_string("""\
 if condition: {{ 1 if foo else 0 }}
 """)
 
-print tmpl.render(foo=True)
+print(tmpl.render(foo=True))


### PR DESCRIPTION
Travis builds fail while running in py3 env because the print statements are in py2 style. 