### PR TITLE
Fix capturing references to external objects

### DIFF
--- a/jinja2/_compat.py
+++ b/jinja2/_compat.py
@@ -133,6 +133,7 @@ except TypeError:
     _tb = sys.exc_info()[2]
     traceback_type = type(_tb)
     frame_type = type(_tb.tb_frame)
+    del _tb
 
 
 try:


### PR DESCRIPTION
_tb was not deleted in except block left in module scope and captured references to external objects by holding on _tb.tb_frame.