### PR TITLE
doc: Mention that urlencode doesn't escape slashes

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -79,7 +79,8 @@ def do_forceescape(value):
 
 def do_urlencode(value):
     """Escape strings for use in URLs (uses UTF-8 encoding).  It accepts both
-    dictionaries and regular strings as well as pairwise iterables.
+    dictionaries and regular strings as well as pairwise iterables. This does
+    not escape slashes ('/').
 
     .. versionadded:: 2.7
     """


### PR DESCRIPTION
Users might be surprised by the fact that urlencode, as driven by
urllib.quote doesn't escape slashes in the URL.

This patch makes that clear in the documentation for the filter.

This fixes #444.
