### PR TITLE
FIX: Filter title, capitalize is registered twice in FILTERS

### DIFF
--- a/jinja2/filters.py
+++ b/jinja2/filters.py
@@ -959,8 +959,6 @@ FILTERS = {
     'reverse':              do_reverse,
     'center':               do_center,
     'indent':               do_indent,
-    'title':                do_title,
-    'capitalize':           do_capitalize,
     'first':                do_first,
     'last':                 do_last,
     'map':                  do_map,


### PR DESCRIPTION
Both filters appear twice in FILTERS registration (second time in reverse order).
That was probably a merge-problem.