### PR TITLE
Remove conditions segment of Django section

### DIFF
--- a/docs/switching.rst
+++ b/docs/switching.rst
@@ -116,37 +116,6 @@ Python syntax. Thus this Django code::
 This allows you to pass variables to the method, which is not possible in
 Django. This syntax is also used for macros.
 
-Conditions
-~~~~~~~~~~
-
-In Django you can use the following constructs to check for equality::
-
-    {% ifequal foo "bar" %}
-        ...
-    {% else %}
-        ...
-    {% endifequal %}
-
-In Jinja2 you can use the normal if statement in combination with operators::
-
-    {% if foo == 'bar' %}
-        ...
-    {% else %}
-        ...
-    {% endif %}
-
-You can also have multiple elif branches in your template::
-
-    {% if something %}
-        ...
-    {% elif otherthing %}
-        ...
-    {% elif foothing %}
-        ...
-    {% else %}
-        ...
-    {% endif %}
-
 Filter Arguments
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* http://jinja.pocoo.org/docs/dev/switching/#conditions has been completely inaccurate since the Django 1.4 release, which was over 2 years ago. Reference: https://docs.djangoproject.com/en/1.4/ref/templates/builtins/#if
* Modern Django (1.8) has full support for `if`, `elif`, and `else` statements: https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#if

Just noticed this discrepancy again while integrating Jinja2 into djangopackages.com. :smile: