### PR TITLE
Added Python 3.5 to tox and Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5.0"
 
 install:
     - pip install tox
 script:
     - tox -e \
-      $(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/')
+      $(echo $TRAVIS_PYTHON_VERSION | sed 's/^\([0-9]\)\.\([0-9]\).*/py\1\2/')
 
 notifications:
   email: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34
+envlist = py26, py27, pypy, py33, py34, py35
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.5 is out. So we should run tests there as well.

Note that Travis currently requires to specify `3.5.0` explicitly.