### PR TITLE
Added pypy to the list of Python versions tested by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 
 install:
     - pip install tox


### PR DESCRIPTION
Travis CI supports PyPy as well. So we should run the tests there as well.

Note that there is also `pypy3`. However, PyPy 3 is currently based on Python 3.2 which isn't supported.