### PR TITLE
Do not hardcode a forward slash as path separator.

### DIFF
--- a/jinja2/loaders.py
+++ b/jinja2/loaders.py
@@ -24,7 +24,7 @@ def split_template_path(template):
     '..' in the path it will raise a `TemplateNotFound` error.
     """
     pieces = []
-    for piece in template.split('/'):
+    for piece in template.split(path.sep):
         if path.sep in piece \
            or (path.altsep and path.altsep in piece) or \
            piece == path.pardir:


### PR DESCRIPTION
path.sep is already being used below, but the hardcoding prevents programs from using something made with path.join on Windows.